### PR TITLE
Use ArduboyTones library for sounds

### DIFF
--- a/longcat/src/Game.cpp
+++ b/longcat/src/Game.cpp
@@ -6,20 +6,19 @@ void Game::setup()
   this->arduboy.setFrameRate(60);
   this->arduboy.initRandomSeed();
 
+  ArduboyTones(this->arduboy.audio.enabled);
+
   Save saveValue;
   if (SaveUtil::tryGet(saveValue))
   {
     this->gameContext.stage = saveValue.lastStage;
-    this->gameContext.audioEnabled = saveValue.audioEnabled;
     this->gameContext.randomDifficulty = saveValue.randomDifficulty;
   }
   else
   {
     this->gameContext.stage = 0;
-    this->gameContext.audioEnabled = true;
     this->gameContext.randomDifficulty = 0;
 
-    saveValue.audioEnabled = true;
     saveValue.lastStage = 0;
     saveValue.randomDifficulty = 0;
     SaveUtil::update(saveValue);
@@ -86,17 +85,17 @@ void Game::loop()
     this->creditsState.update(*this);
     this->creditsState.render(*this);
     break;
-	
+
   case GameState::OptionsMenu:
     this->optionsMenuState.update(*this);
     this->optionsMenuState.render(*this);
     break;
-	
+
   case GameState::EndScreen:
     this->endScreenState.update(*this);
     this->endScreenState.render(*this);
     break;
-	
+
   default:
     this->setGameState(GameState::SplashScreen);
   }

--- a/longcat/src/Game.h
+++ b/longcat/src/Game.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduboy2.h>
+#include <ArduboyTones.h>
 
 #include "States/GameState.h"
 
@@ -25,7 +26,6 @@ private:
 
 private:
   Arduboy2 arduboy;
-  BeepPin2 beep;
   GameStateSplashScreen splashScreenState;
   GameStateMainMenu mainMenuState;
   GameStateSelectLevel selectLevelState;
@@ -42,12 +42,9 @@ private:
 public:
   void clickSound()
   {
-	if(this->gameContext.audioEnabled)
-	{
-      beep.tone(beep.freq(100), 20);
-	}
+    ArduboyTones::tone(100, 20);
   }
-  
+
   void setGameMode(GameMode gameMode)
   {
     this->gameMode = gameMode;

--- a/longcat/src/GameContext/GameContext.h
+++ b/longcat/src/GameContext/GameContext.h
@@ -12,6 +12,5 @@ public:
   Map mapObject;
   Hero hero;
   //Settings
-  bool audioEnabled;
   uint8_t randomDifficulty;
 };

--- a/longcat/src/States/GameStateOptionsMenu.cpp
+++ b/longcat/src/States/GameStateOptionsMenu.cpp
@@ -10,7 +10,7 @@ void GameStateOptionsMenu::update(Game &game)
   {
     game.setGameState(GameState::MainMenu);
   }
-  
+
 	if (arduboy.justPressed(UP_BUTTON))
 	{
 		if (this->selection > 0)
@@ -28,20 +28,18 @@ void GameStateOptionsMenu::update(Game &game)
 		{
 			case 0:
 			{
-				context.audioEnabled = !context.audioEnabled;
-				Save saveValue;
-				if (SaveUtil::tryGet(saveValue))
-				  {
-					saveValue.audioEnabled = context.audioEnabled;
-				  }
-				  else
-				  {
-					saveValue.lastStage = 0;
-					saveValue.audioEnabled = context.audioEnabled;
-					saveValue.randomDifficulty = 0;
 
-					SaveUtil::update(saveValue);
-				  }
+				if (arduboy.audio.enabled())
+				{
+					arduboy.audio.off();
+				}
+				else
+				{
+					arduboy.audio.on();
+				}
+				arduboy.audio.saveOnOff();
+				ArduboyTones::tone(NOTE_CS6, 30);
+
 				this->selection = 0;
 				break;
 			}
@@ -55,12 +53,12 @@ void GameStateOptionsMenu::render(Game &game)
   auto &arduboy = game.getArduboy();
   auto &context = game.getGameContext();
   arduboy.fillScreen(WHITE);
-  
+
 	const char *line_0 = "Options:";
 	const char *line_1 = "  Sound ON";
 	const char *line_2 = "  Sound OFF";
 	const char *strings[] = {line_0, line_1};
-	if(!context.audioEnabled){
+	if(!arduboy.audio.enabled()){
 		strings[1] = line_2;
 	}
 	for (uint8_t i = 0; i < 2; i++)

--- a/longcat/src/Utils/SaveUtil.cpp
+++ b/longcat/src/Utils/SaveUtil.cpp
@@ -3,7 +3,6 @@
 uint16_t SaveUtil::hash(Save value)
 {
     uint16_t runner = static_cast<uint16_t>(value.lastStage);
-    runner ^= static_cast<uint16_t>(value.audioEnabled);
     runner ^= static_cast<uint16_t>(value.randomDifficulty);
 }
 

--- a/longcat/src/Utils/SaveUtil.h
+++ b/longcat/src/Utils/SaveUtil.h
@@ -7,7 +7,6 @@ struct Save
 {
     uint16_t hash;
     uint8_t lastStage;
-    bool audioEnabled;
     uint8_t randomDifficulty;
 };
 


### PR DESCRIPTION
Hi.  Not sure if you want to merge this, but I thought I'd share.  I was having some issues with sounds not stopping after the intended 20ms duration on my homemade arduboy FX.  I was able to get it working by adding a `timer()` call for each frame in the loop ([as per this doc](https://mlxxxp.github.io/documents/Arduino/libraries/Arduboy2/Doxygen/html/classBeepPin1.html)), but felt it was better to  use the ArduboyTones library.

Using the [ArduboyTones library](https://github.com/MLXXXp/ArduboyTones) allows the sound state to be initialized using the Arduboy `audio.enabled` state, which is nice since it persists between different game launches with the FX.  

Accordingly, I also removed the `audioEnabled` save state, and set the global arduboy audio state when the options menu sound is enabled/disabled.